### PR TITLE
Use latest ueberauth_slack version to 0.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule UeberauthExample.Mixfile do
      {:ueberauth_google, "~> 0.2"},
      {:ueberauth_github, "~> 0.2"},
      {:ueberauth_identity, "~> 0.2"},
-     {:ueberauth_slack, "~> 0.2"},
+     {:ueberauth_slack, "~> 0.4"},
      {:ueberauth_twitter, "~> 0.2"},
 
      {:dogma, ">= 0.0.0", only: [:dev, :test]}


### PR DESCRIPTION
There are some issues with 0.2 version of ueberauth_slack. This 0.4 version works fine. 